### PR TITLE
Fix golangci-lint shadow

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,7 @@
 linters-settings:
   govet:
-    check-shadowing: true
+    enable:
+      - shadow
   golint:
     min-confidence: 0.8
   gocyclo:


### PR DESCRIPTION
This caused golangci-lint config validation errors